### PR TITLE
Add the CI CD part to publish the project to Maven central.

### DIFF
--- a/.github/workflows/publish-project.yml
+++ b/.github/workflows/publish-project.yml
@@ -9,22 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        uses: actions/checkout@v4
 
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
           java-version: '11'
+          distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
@@ -32,7 +23,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Apache Maven Central
-        run: mvn clean deploy -P release -Dmaven.test.skip=true
+        run: mvn clean deploy -P release --batch-mode -Dmaven.test.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Add the CI CD part to publish the project to Maven central and to launch unit tests with GitHub Actions. Configure the GPG key in the CI CD part (Maven + GHA).